### PR TITLE
Add API endpoint to delete a registered user (resolves joohoi/acme-dns#177)

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,6 +75,26 @@ With the credentials, you can update the TXT response in the service to match th
 }
 ```
 
+### Unregister endpoint
+
+This method deletes a registered user and the associated TXT records from the database. The subdomain has to be sent as JSON input. The user's credentials must be provided like with an update update request.
+
+#### Example input
+```json
+{
+    "subdomain": "0b3736b4-32dd-43c1-8b4f-db117767b3ca"
+}
+```
+
+#### Response
+
+```Status: 200 OK```
+```json
+{
+    "unregister": "c2d7e8fd-ff4c-41c6-8f16-1d76628cbfde"
+}
+```
+
 ### Update endpoint
 
 The method allows you to update the TXT answer contents of your unique subdomain. Usually carried automatically by automated ACME client.

--- a/api.go
+++ b/api.go
@@ -6,6 +6,7 @@ import (
 	"io/ioutil"
 	"net/http"
 
+	"github.com/google/uuid"
 	"github.com/julienschmidt/httprouter"
 	log "github.com/sirupsen/logrus"
 )
@@ -17,6 +18,12 @@ type RegResponse struct {
 	Fulldomain string   `json:"fulldomain"`
 	Subdomain  string   `json:"subdomain"`
 	Allowfrom  []string `json:"allowfrom"`
+}
+
+// UnregRequest is a struct providing the data to unregister
+type UnregRequest struct {
+	Username  uuid.UUID `json:"username"`
+	Subdomain string    `json:"subdomain"`
 }
 
 func webRegisterPost(w http.ResponseWriter, r *http.Request, _ httprouter.Params) {
@@ -69,6 +76,32 @@ func webRegisterPost(w http.ResponseWriter, r *http.Request, _ httprouter.Params
 	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(regStatus)
 	w.Write(reg)
+}
+
+func webUnregisterPost(w http.ResponseWriter, r *http.Request, _ httprouter.Params) {
+	var unregStatus int
+	var err error
+	var upd []byte
+
+	// Get user data
+	unregData, ok := r.Context().Value(ACMETxtKey).(UnregRequest)
+	if !ok {
+		log.WithFields(log.Fields{"error": "context"}).Error("Context error")
+	}
+
+	// Delete user
+	err = DB.Unregister(unregData.Username)
+	if err != nil {
+		unregStatus = http.StatusInternalServerError
+		upd = jsonError(fmt.Sprintf("%s (%v)", "delete_error", err))
+	} else {
+		log.WithFields(log.Fields{"user": unregData.Username.String()}).Debug("Deleted user")
+		upd = []byte("{\"unregister\": \"" + unregData.Username.String() + "\"}")
+		unregStatus = http.StatusOK
+	}
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(unregStatus)
+	w.Write(upd)
 }
 
 func webUpdatePost(w http.ResponseWriter, r *http.Request, _ httprouter.Params) {

--- a/main.go
+++ b/main.go
@@ -125,8 +125,9 @@ func startHTTPAPI(errChan chan error, config DNSConfig, dnsservers []*DNSServer)
 	}
 	if !Config.API.DisableRegistration {
 		api.POST("/register", webRegisterPost)
+		api.POST("/unregister", AuthUnregister(webUnregisterPost))
 	}
-	api.POST("/update", Auth(webUpdatePost))
+	api.POST("/update", AuthUpdate(webUpdatePost))
 	api.GET("/health", healthCheck)
 
 	host := Config.API.IP + ":" + Config.API.Port

--- a/types.go
+++ b/types.go
@@ -72,6 +72,7 @@ type acmedb struct {
 type database interface {
 	Init(string, string) error
 	Register(cidrslice) (ACMETxt, error)
+	Unregister(uuid.UUID) error
 	GetByUsername(uuid.UUID) (ACMETxt, error)
 	GetTXTForDomain(string) ([]string, error)
 	Update(ACMETxtPost) error


### PR DESCRIPTION
This PR implements an API endpoint to delete registered users if they aren't neded anymore. Please check and merge.