### PR TITLE
validation: allow up to 200 chars of txt content

### DIFF
--- a/util.go
+++ b/util.go
@@ -59,7 +59,7 @@ func prepareConfig(conf DNSConfig) (DNSConfig, error) {
 
 func sanitizeString(s string) string {
 	// URL safe base64 alphabet without padding as defined in ACME
-	re, _ := regexp.Compile(`[^A-Za-z\-\_0-9]+`)
+	re, _ := regexp.Compile(`[^A-Za-z\-\_\.0-9]+`)
 	return re.ReplaceAllString(s, "")
 }
 

--- a/validation.go
+++ b/validation.go
@@ -33,7 +33,9 @@ func validSubdomain(s string) bool {
 
 func validTXT(s string) bool {
 	sn := sanitizeString(s)
-	if utf8.RuneCountInString(s) == 43 && utf8.RuneCountInString(sn) == 43 {
+	cnt := utf8.RuneCountInString(s)
+	cnt_sn := utf8.RuneCountInString(sn)
+	if (43 <= cnt && cnt <= 200 && cnt_sn == cnt) {
 		// 43 chars is the current LE auth key size, but not limited / defined by ACME
 		return true
 	}


### PR DESCRIPTION
LE now seems to issue 83-character long tokens containing dots.
