### PR TITLE
get endpoint idea

### DIFF
--- a/README.md
+++ b/README.md
@@ -226,6 +226,22 @@ Note: The `txt` field must be exactly 43 characters long, otherwise acme-dns wil
 $ dig -t txt @auth.example.org d420c923-bbd7-4056-ab64-c3ca54c9b3cf.auth.example.org
 ```
 
+5) If you need to test stored credentials in the future, call the `/get` API endpoint to retrieve the TXT record. Pass the `username`, `password` and `subdomain` received from the `register` call performed above:
+```
+$ curl -X POST \
+  -H "X-Api-User: eabcdb41-d89f-4580-826f-3e62e9755ef2" \
+  -H "X-Api-Key: pbAXVjlIOE01xbut7YnAbkhMQIkcwoHO0ek2j4Q0" \
+  -d '{"subdomain": "d420c923-bbd7-4056-ab64-c3ca54c9b3cf"}' \
+  https://auth.example.org/get
+```
+
+If the credentials are active, you will receive the current TXT record:
+
+```
+{"txt": "FNWgZ4KcKbEWLljs3ZTIEq_y0N3D0yAYqGAaSiJtLIo"}
+```
+
+
 ## Configuration
 
 ```bash

--- a/api.go
+++ b/api.go
@@ -107,6 +107,46 @@ func webUpdatePost(w http.ResponseWriter, r *http.Request, _ httprouter.Params) 
 	_, _ = w.Write(upd)
 }
 
+// this is a version of `webUpdatePost` that does not write
+func webGetPost(w http.ResponseWriter, r *http.Request, _ httprouter.Params) {
+	var updStatus int
+	var upd []byte
+	// Get user
+	a, ok := r.Context().Value(ACMETxtKey).(ACMETxt)
+	if !ok {
+		log.WithFields(log.Fields{"error": "context"}).Error("Context error")
+	}
+	// NOTE: An invalid subdomain should not happen - the auth handler should
+	// reject POSTs with an invalid subdomain before this handler. Reject any
+	// invalid subdomains anyway as a matter of caution.
+	if !validSubdomain(a.Subdomain) {
+		log.WithFields(log.Fields{"error": "subdomain", "subdomain": a.Subdomain, "txt": a.Value}).Debug("Bad update data")
+		updStatus = http.StatusBadRequest
+		upd = jsonError("bad_subdomain")
+	} else if !validTXT(a.Value) {
+		log.WithFields(log.Fields{"error": "txt", "subdomain": a.Subdomain, "txt": a.Value}).Debug("Bad update data")
+		updStatus = http.StatusBadRequest
+		upd = jsonError("bad_txt")
+	} else if validSubdomain(a.Subdomain) && validTXT(a.Value) {
+		atxt, err := DB.GetTXTForDomain(a.Subdomain)
+		if err != nil {
+			log.WithFields(log.Fields{"error": err.Error()}).Debug("Error while trying to get record")
+			updStatus = http.StatusInternalServerError
+			upd = jsonError("db_error")
+		} else {
+			for _, v := range atxt {
+				if len(v) > 0 {
+					updStatus = http.StatusOK
+					upd = []byte("{\"txt\": \"" + v + "\"}")
+				}
+			}
+		}
+	}
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(updStatus)
+	_, _ = w.Write(upd)
+}
+
 // Endpoint used to check the readiness and/or liveness (health) of the server.
 func healthCheck(w http.ResponseWriter, r *http.Request, _ httprouter.Params) {
 	w.WriteHeader(http.StatusOK)

--- a/api.go
+++ b/api.go
@@ -107,7 +107,8 @@ func webUpdatePost(w http.ResponseWriter, r *http.Request, _ httprouter.Params) 
 	_, _ = w.Write(upd)
 }
 
-// this is a version of `webUpdatePost` that does not write
+// this is a version of `webUpdatePost` that does not update or accept TXT record
+// it is used to check credentials
 func webGetPost(w http.ResponseWriter, r *http.Request, _ httprouter.Params) {
 	var updStatus int
 	var upd []byte
@@ -116,29 +117,16 @@ func webGetPost(w http.ResponseWriter, r *http.Request, _ httprouter.Params) {
 	if !ok {
 		log.WithFields(log.Fields{"error": "context"}).Error("Context error")
 	}
-	// NOTE: An invalid subdomain should not happen - the auth handler should
-	// reject POSTs with an invalid subdomain before this handler. Reject any
-	// invalid subdomains anyway as a matter of caution.
-	if !validSubdomain(a.Subdomain) {
-		log.WithFields(log.Fields{"error": "subdomain", "subdomain": a.Subdomain, "txt": a.Value}).Debug("Bad update data")
-		updStatus = http.StatusBadRequest
-		upd = jsonError("bad_subdomain")
-	} else if !validTXT(a.Value) {
-		log.WithFields(log.Fields{"error": "txt", "subdomain": a.Subdomain, "txt": a.Value}).Debug("Bad update data")
-		updStatus = http.StatusBadRequest
-		upd = jsonError("bad_txt")
-	} else if validSubdomain(a.Subdomain) && validTXT(a.Value) {
-		atxt, err := DB.GetTXTForDomain(a.Subdomain)
-		if err != nil {
-			log.WithFields(log.Fields{"error": err.Error()}).Debug("Error while trying to get record")
-			updStatus = http.StatusInternalServerError
-			upd = jsonError("db_error")
-		} else {
-			for _, v := range atxt {
-				if len(v) > 0 {
-					updStatus = http.StatusOK
-					upd = []byte("{\"txt\": \"" + v + "\"}")
-				}
+	atxt, err := DB.GetTXTForDomain(a.Subdomain)
+	if err != nil {
+		log.WithFields(log.Fields{"error": err.Error()}).Debug("Error while trying to get record")
+		updStatus = http.StatusInternalServerError
+		upd = jsonError("db_error")
+	} else {
+		for _, v := range atxt {
+			if len(v) > 0 {
+				updStatus = http.StatusOK
+				upd = []byte("{\"txt\": \"" + v + "\"}")
 			}
 		}
 	}

--- a/api_test.go
+++ b/api_test.go
@@ -293,6 +293,18 @@ func TestApiUpdateWithCredentials(t *testing.T) {
 		ContainsKey("txt").
 		NotContainsKey("error").
 		ValueEqual("txt", validTxtData)
+
+	// the get endpoint...
+	e.POST("/get").
+		WithJSON(updateJSON).
+		WithHeader("X-Api-User", newUser.Username.String()).
+		WithHeader("X-Api-Key", newUser.Password).
+		Expect().
+		Status(http.StatusOK).
+		JSON().Object().
+		ContainsKey("txt").
+		NotContainsKey("error").
+		ValueEqual("txt", validTxtData)
 }
 
 func TestApiUpdateWithCredentialsMockDB(t *testing.T) {

--- a/api_test.go
+++ b/api_test.go
@@ -74,10 +74,10 @@ func setupRouter(debug bool, noauth bool) http.Handler {
 	api.GET("/health", healthCheck)
 	if noauth {
 		api.POST("/update", noAuth(webUpdatePost))
-		api.POST("/get", noAuth(weGetPost))
+		api.POST("/get", noAuth(webGetPost))
 	} else {
 		api.POST("/update", Auth(webUpdatePost))
-		api.POST("/get", Auth(weGetPost))
+		api.POST("/get", Auth(webGetPost))
 	}
 	return c.Handler(api)
 }

--- a/api_test.go
+++ b/api_test.go
@@ -74,8 +74,10 @@ func setupRouter(debug bool, noauth bool) http.Handler {
 	api.GET("/health", healthCheck)
 	if noauth {
 		api.POST("/update", noAuth(webUpdatePost))
+		api.POST("/get", noAuth(weGetPost))
 	} else {
 		api.POST("/update", Auth(webUpdatePost))
+		api.POST("/get", Auth(weGetPost))
 	}
 	return c.Handler(api)
 }

--- a/main.go
+++ b/main.go
@@ -127,6 +127,7 @@ func startHTTPAPI(errChan chan error, config DNSConfig, dnsservers []*DNSServer)
 		api.POST("/register", webRegisterPost)
 	}
 	api.POST("/update", Auth(webUpdatePost))
+	api.POST("/get", Auth(webGetPost))
 	api.GET("/health", healthCheck)
 
 	host := Config.API.IP + ":" + Config.API.Port


### PR DESCRIPTION
fixes #377 

adds `/get` endpoint, which requires the same params as `/update` BUT does not write the txt value and returns the existing txt value

Originally: I would rather have not required a subdomain for POST, but this leverages the existing auth AND works as a decent dry-run .  someone more familiar with Go could write a much better PR.  this is just a proof of concept.

Now:  Requiring the subdomain makes sense, and I refactored the code.