### PR TITLE
A few changes to the Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,23 +1,22 @@
-FROM golang:alpine AS builder
+FROM golang:bookworm AS builder
 LABEL maintainer="joona@kuori.org"
 
-RUN apk add --update gcc musl-dev git
 
-ENV GOPATH /tmp/buildcache
-RUN git clone https://github.com/joohoi/acme-dns /tmp/acme-dns
+ENV GOPATH=/tmp/buildcache
+COPY *.go *.mod *.sum /tmp/acme-dns/
 WORKDIR /tmp/acme-dns
 RUN CGO_ENABLED=1 go build
+RUN mkdir /tmp/dir
 
-FROM alpine:latest
+FROM gcr.io/distroless/base-debian12:nonroot
 
+USER nonroot:nonroot
 WORKDIR /root/
-COPY --from=builder /tmp/acme-dns .
-RUN mkdir -p /etc/acme-dns
-RUN mkdir -p /var/lib/acme-dns
-RUN rm -rf ./config.cfg
-RUN apk --no-cache add ca-certificates && update-ca-certificates
+COPY --from=builder /tmp/acme-dns/acme-dns /acme-dns
+COPY --from=builder /tmp/dir /etc/acme-dns
+COPY --from=builder /tmp/dir /var/lib/acme-dns
 
 VOLUME ["/etc/acme-dns", "/var/lib/acme-dns"]
-ENTRYPOINT ["./acme-dns"]
+ENTRYPOINT ["/acme-dns"]
 EXPOSE 53 80 443
 EXPOSE 53/udp


### PR DESCRIPTION
Submitting this as a PR mainly to solicit feedback and discuss potentially contributing documentation on how to best run acme-dns in Kubernetes. Since I wanted to build the docker images for arm64 anyway, I thought I might as well make some other changes:

* Use a distroless base image instead of the alpine base for security hardening
* Use golang:bookworm as build image
* Build the currently checked out tree instead of the lastet main branch from github

The last one bit me a little as I tried making some changes to the local repository, only to have `docker build` build from the latest master commit, disregarding my local changes.

One thing that differs with this docker image compared to the previous one is that as it is set up to run as an unprivileged user, the process does not have permission to open ports under 1024 without special capabilities configuration. In Kubernetes, ports can be remapped via the Service or some Ingress or Gateway implementation, so this is not a problem, but I guess it would require some rewriting of the current docker setup documentation.