### PR TITLE
fix: update golangci-lint to v1.64.8 to resolve linter errors

### DIFF
--- a/.github/workflows/golangci-lint.yml
+++ b/.github/workflows/golangci-lint.yml
@@ -25,5 +25,5 @@ jobs:
       - name: golangci-lint
         uses: golangci/golangci-lint-action@v6
         with:
-          version: v1.60
+          version: v1.64.8
           args: --timeout=10m


### PR DESCRIPTION
In the current version (v1.60) the linter action fails with errors:

```
Running [/home/runner/golangci-lint-1.60.3-linux-amd64/golangci-lint config path] in [/home/runner/work/acme-dns/acme-dns] ...
  Running [/home/runner/golangci-lint-1.60.3-linux-amd64/golangci-lint run  --timeout=10m] in [/home/runner/work/acme-dns/acme-dns] ...
  Error: validation.go:4:2: could not import unicode/utf8 (-: could not load export data: internal error in importing "unicode/utf8" (unsupported version: 2); please report an issue) (typecheck)
  	"unicode/utf8"
  	^
  Error: api_test.go:182:17: undefined: sqlmock (typecheck)
  	db, mock, _ := sqlmock.New()
  	               ^
  Error: api_test.go:[31](https://github.com/michvllni/acme-dns/actions/runs/15729056033/job/44325629202#step:4:33)1:17: undefined: sqlmock (typecheck)
  	db, mock, _ := sqlmock.New()
  	               ^
  Error: db_test.go:31:2: undefined: testdb (typecheck)
  	testdb.SetExecWithArgsFunc(func(query string, args []driver.Value) (result driver.Result, err error) {
  	^
  Error: db_test.go:[34](https://github.com/michvllni/acme-dns/actions/runs/15729056033/job/44325629202#step:4:36):8: undefined: testdb (typecheck)
  	defer testdb.Reset()
  	      ^
  Error: db_test.go:114:8: undefined: testdb (typecheck)
  	defer testdb.Reset()
  	      ^
  
  Error: issues found
  Ran golangci-lint in 51617ms
```

Updating to 1.64.8 (latest 1.X) resolves this.

We should make plans to migrate to version 2, but at the moment it threw to many errors for me to safely resolve them without further discussion.