### PR TITLE
feat: Support listening on multiple individual IPs

### DIFF
--- a/main.go
+++ b/main.go
@@ -210,7 +210,6 @@ func getProtocols(proto string) []string {
 	switch proto {
 	case "udp", "udp4", "udp6", "tcp", "tcp4", "tcp6":
 		return []string{proto}
-		return []string{"udp"}
 	case "both":
 		return []string{"tcp", "udp"}
 	case "both4":

--- a/main.go
+++ b/main.go
@@ -61,32 +61,28 @@ func main() {
 
 	// DNS server
 	dnsservers := make([]*DNSServer, 0)
-	if strings.HasPrefix(Config.General.Proto, "both") {
-		// Handle the case where DNS server should be started for both udp and tcp
-		udpProto := "udp"
-		tcpProto := "tcp"
-		if strings.HasSuffix(Config.General.Proto, "4") {
-			udpProto += "4"
-			tcpProto += "4"
-		} else if strings.HasSuffix(Config.General.Proto, "6") {
-			udpProto += "6"
-			tcpProto += "6"
+	protos := getProtocols(Config.General.Proto)
+	listenAddrs := parseListen(Config.General.Listen)
+
+	for _, addr := range listenAddrs {
+		for _, proto := range protos {
+			dnsServer := NewDNSServer(DB, addr, proto, Config.General.Domain)
+
+			// Only parse records on the very first server.
+			if len(dnsservers) == 0 {
+				dnsServer.ParseRecords(Config)
+			} else {
+				// Copy already-parsed data from the first server.
+				dnsServer.Domains = dnsservers[0].Domains
+				dnsServer.SOA = dnsservers[0].SOA
+			}
+
+			// Start the DNS server in its own goroutine.
+			go dnsServer.Start(errChan)
+
+			// Store it in the slice.
+			dnsservers = append(dnsservers, dnsServer)
 		}
-		dnsServerUDP := NewDNSServer(DB, Config.General.Listen, udpProto, Config.General.Domain)
-		dnsservers = append(dnsservers, dnsServerUDP)
-		dnsServerUDP.ParseRecords(Config)
-		dnsServerTCP := NewDNSServer(DB, Config.General.Listen, tcpProto, Config.General.Domain)
-		dnsservers = append(dnsservers, dnsServerTCP)
-		// No need to parse records from config again
-		dnsServerTCP.Domains = dnsServerUDP.Domains
-		dnsServerTCP.SOA = dnsServerUDP.SOA
-		go dnsServerUDP.Start(errChan)
-		go dnsServerTCP.Start(errChan)
-	} else {
-		dnsServer := NewDNSServer(DB, Config.General.Listen, Config.General.Proto, Config.General.Domain)
-		dnsservers = append(dnsservers, dnsServer)
-		dnsServer.ParseRecords(Config)
-		go dnsServer.Start(errChan)
 	}
 
 	// HTTP API
@@ -207,4 +203,43 @@ func startHTTPAPI(errChan chan error, config DNSConfig, dnsservers []*DNSServer)
 	if err != nil {
 		errChan <- err
 	}
+}
+
+func getProtocols(proto string) []string {
+	switch strings.ToLower(strings.TrimSpace(proto)) {
+	case "udp":
+		return []string{"udp"}
+	case "tcp":
+		return []string{"tcp"}
+	case "both":
+		return []string{"tcp", "udp"}
+	case "both4":
+		return []string{"tcp4", "udp4"}
+	case "both6":
+		return []string{"tcp6", "udp6"}
+	default:
+		// fallback if misconfigured
+		return []string{"udp"}
+	}
+}
+
+func parseListen(listen string) []string {
+	listen = strings.TrimSpace(listen)
+	if listen == "" {
+		return nil
+	}
+
+	parts := strings.Split(listen, ",")
+	addrs := make([]string, 0, len(parts))
+
+	for _, p := range parts {
+		p = strings.TrimSpace(p)
+		if p == "" {
+			continue
+		}
+		// Here we accept IPv4 "ip:port" and IPv6 "[ip]:port" as-is.
+		addrs = append(addrs, p)
+	}
+
+	return addrs
 }

--- a/main.go
+++ b/main.go
@@ -206,11 +206,11 @@ func startHTTPAPI(errChan chan error, config DNSConfig, dnsservers []*DNSServer)
 }
 
 func getProtocols(proto string) []string {
-	switch strings.ToLower(strings.TrimSpace(proto)) {
-	case "udp":
+	proto = strings.ToLower(strings.TrimSpace(proto))
+	switch proto {
+	case "udp", "udp4", "udp6", "tcp", "tcp4", "tcp6":
+		return []string{proto}
 		return []string{"udp"}
-	case "tcp":
-		return []string{"tcp"}
 	case "both":
 		return []string{"tcp", "udp"}
 	case "both4":

--- a/main.go
+++ b/main.go
@@ -208,8 +208,6 @@ func startHTTPAPI(errChan chan error, config DNSConfig, dnsservers []*DNSServer)
 func getProtocols(proto string) []string {
 	proto = strings.ToLower(strings.TrimSpace(proto))
 	switch proto {
-	case "udp", "udp4", "udp6", "tcp", "tcp4", "tcp6":
-		return []string{proto}
 	case "both":
 		return []string{"tcp", "udp"}
 	case "both4":
@@ -217,8 +215,8 @@ func getProtocols(proto string) []string {
 	case "both6":
 		return []string{"tcp6", "udp6"}
 	default:
-		// fallback if misconfigured
-		return []string{"udp"}
+		// all other options
+		return []string{proto}
 	}
 }
 

--- a/main_test.go
+++ b/main_test.go
@@ -70,7 +70,7 @@ func setupConfig() {
 
 	var generalcfg = general{
 		Domain:        "auth.example.org",
-		Listen:        "127.0.0.1:15353",
+		Listen:        " ,[::1]:15353,,,127.0.0.1:15353 ",
 		Proto:         "udp",
 		Nsname:        "ns1.auth.example.org",
 		Nsadmin:       "admin.example.org",


### PR DESCRIPTION
Hello,

this change adds support of specifying multiple explicitly configured listening IP addresses. This was previously not possible - either the service was listening on `any` (`0.0.0.0`/`::`) or on one address picked up by the operator (which may not be enough in dual-stacked environments).

This is useful in environments where you have multiple DNS servers listening on 53 (udp or tcp) and you want to distinguish between them by IPs. One DNS server may be listening on `127.0.0.1:53, [::1]:53`, and another one on public IPs, e.g. `192.0.2.1:53,[2001:db8::1]:53`.

Likely resolves #135 