### PR TITLE
Add txt_limit config option

### DIFF
--- a/Dockerfile.local
+++ b/Dockerfile.local
@@ -1,0 +1,34 @@
+# Docker file for build from local sources (without pulling git repo)
+# Example:
+#   docker build -f Dockerfile.local \
+#     -t registry.local/path/acme-dns:v2.0.2_customVersion .
+
+FROM golang:alpine AS builder
+LABEL maintainer="joona@kuori.org"
+
+ENV GOPATH /tmp/buildcache
+WORKDIR /tmp/acme-dns
+
+# to cache deps in own docker layer
+COPY go.mod go.sum ./
+RUN go mod download
+
+# then build to another docker layer
+COPY . .
+#RUN CGO_ENABLED=0 go build
+# or flags for production
+RUN CGO_ENABLED=0 go build -ldflags="-w -s"
+
+FROM alpine:latest
+
+WORKDIR /root/
+COPY --from=builder /tmp/acme-dns .
+RUN mkdir -p /etc/acme-dns
+RUN mkdir -p /var/lib/acme-dns
+RUN rm -rf ./config.cfg
+RUN apk --no-cache add ca-certificates && update-ca-certificates
+
+VOLUME ["/etc/acme-dns", "/var/lib/acme-dns"]
+ENTRYPOINT ["./acme-dns"]
+EXPOSE 53 80 443
+EXPOSE 53/udp

--- a/config.cfg
+++ b/config.cfg
@@ -13,13 +13,16 @@ nsname = "auth.example.org"
 nsadmin = "admin.example.org"
 # predefined records served in addition to the TXT
 records = [
-    # domain pointing to the public IP of your acme-dns server 
+    # domain pointing to the public IP of your acme-dns server
     "auth.example.org. A 198.51.100.1",
     # specify that auth.example.org will resolve any *.auth.example.org records
     "auth.example.org. NS auth.example.org.",
 ]
 # debug messages from CORS etc
 debug = false
+
+# Number of TXT records per account
+txt_limit = 2
 
 [database]
 # Database engine to use, sqlite or postgres

--- a/pkg/acmedns/config.go
+++ b/pkg/acmedns/config.go
@@ -47,6 +47,11 @@ func prepareConfig(conf AcmeDnsConfig) (AcmeDnsConfig, error) {
 		return conf, errors.New("missing database configuration option \"connection\"")
 	}
 
+	// check for txt_limit, set default to 2 if not specified or equal 0
+	if conf.General.Txtlimit == 0 {
+		conf.General.Txtlimit = 2
+	}
+
 	// Default values for options added to config to keep backwards compatibility with old config
 	if conf.API.ACMECacheDir == "" {
 		conf.API.ACMECacheDir = "api-certs"

--- a/pkg/acmedns/types.go
+++ b/pkg/acmedns/types.go
@@ -25,6 +25,7 @@ type general struct {
 	Nsadmin       string
 	Debug         bool
 	StaticRecords []string `toml:"records"`
+	Txtlimit      int      `toml:"txt_limit"`
 }
 
 type dbsettings struct {

--- a/pkg/database/db.go
+++ b/pkg/database/db.go
@@ -178,11 +178,14 @@ func (d *acmednsdb) handleDBUpgradeTo1() error {
 
 // NewTXTValuesInTransaction creates two rows for subdomain to the txt table
 func (d *acmednsdb) NewTXTValuesInTransaction(tx *sql.Tx, subdomain string) error {
-	var err error
 	instr := fmt.Sprintf("INSERT INTO txt (Subdomain, LastUpdate) values('%s', 0)", subdomain)
-	_, _ = tx.Exec(instr)
-	_, _ = tx.Exec(instr)
-	return err
+	for i := 0; i < d.Config.General.Txtlimit; i++ {
+		_, err := tx.Exec(instr)
+		if err != nil {
+			return err
+		}
+	}
+	return nil
 }
 
 func (d *acmednsdb) Register(afrom acmedns.Cidrslice) (acmedns.ACMETxt, error) {
@@ -268,9 +271,11 @@ func (d *acmednsdb) GetTXTForDomain(domain string) ([]string, error) {
 	defer d.Mutex.Unlock()
 	domain = acmedns.SanitizeString(domain)
 	var txts []string
-	getSQL := `
-	SELECT Value FROM txt WHERE Subdomain=$1 LIMIT 2
-	`
+
+	getSQL := fmt.Sprintf(`
+			SELECT Value FROM txt WHERE Subdomain=$1 LIMIT %d
+	`, d.Config.General.Txtlimit)
+
 	if d.Config.Database.Engine == "sqlite" {
 		getSQL = getSQLiteStmt(getSQL)
 	}


### PR DESCRIPTION
Adds txt_limit config option which allows to specify number of TXT records per subdomains.
acme-dns has hardcoded limit for only two TXT records and this is enough for almost all LE certs.
But in some cases two TXT per account is not enough. For example:

1. Cert with multiple domains
- acme.sh + acme-dns is used
- need to issue cert with named "domain1.com, *.domain1.com, domain2.com"
- acme.sh has no ability to specify DNS management account1 for domain1 and account2 for domain2 and user has to use single acme-dns account for all domains in single cert
2. some one can use single acme-dns account for all his domain and can get issues for limit in two TXT records

Option 'txt_limit' allows to increase number of TXT record for these specific cases and the default number is two.

Also "Dockerfile.local" is provided for build from local sources. Build is splitted in two parts (multiple docker layers): layers for do deps and layers for bo build. This allows to re-use go deps installed previously and cached in docker cache