### PR TITLE
Fix CertMagic cache initialization

### DIFF
--- a/pkg/api/api.go
+++ b/pkg/api/api.go
@@ -124,12 +124,13 @@ func (a *AcmednsAPI) setupTLS(dnsservers []acmedns.AcmednsNS) *certmagic.Config 
 	magicConf.Logger = a.Logger.Desugar()
 	magicConf.Storage = &storage
 	magicConf.DefaultServerName = a.Config.General.Domain
+	var magic *certmagic.Config
 	magicCache := certmagic.NewCache(certmagic.CacheOptions{
 		GetConfigForCert: func(cert certmagic.Certificate) (*certmagic.Config, error) {
-			return &magicConf, nil
+			return magic, nil
 		},
 		Logger: a.Logger.Desugar(),
 	})
-	magic := certmagic.New(magicCache, magicConf)
+	magic = certmagic.New(magicCache, magicConf)
 	return magic
 }


### PR DESCRIPTION
The current `master` returns the uninitialized CertMagic configuration in the `GetConfigForCert` callback function. It should return the return value of `certmagic.New` – only this config has the cache set.

Fixes errors like these:
```
error        unable to get configuration to manage certificate; unable to renew        {"identifiers": ["configured.example.com"], "error": "config returned for certificate [configured.example.com] has nil cache; expected 0xc0000bb080 (this one)"}
```

Fixes #337 for refactored code
