### PR TITLE
Add HSTS middleware

### DIFF
--- a/config.cfg
+++ b/config.cfg
@@ -53,6 +53,14 @@ corsorigins = [
 use_header = false
 # header name to pull the ip address / list of ip addresses from
 header_name = "X-Forwarded-For"
+# enable HSTS (HTTP Strict Transport Security)
+hsts_enabled = false
+# HSTS max age in seconds (default: 31536000 = 1 year)
+hsts_max_age = 31536000
+# HSTS include subdomains directive
+hsts_include_subdomains = false
+# HSTS preload directive
+hsts_preload = false
 
 [logconfig]
 # logging level: "error", "warning", "info" or "debug"

--- a/pkg/acmedns/types.go
+++ b/pkg/acmedns/types.go
@@ -47,6 +47,10 @@ type httpapi struct {
 	CorsOrigins         []string
 	UseHeader           bool   `toml:"use_header"`
 	HeaderName          string `toml:"header_name"`
+	HSTSEnabled         bool   `toml:"hsts_enabled"`
+	HSTSMaxAge          int    `toml:"hsts_max_age"`
+	HSTSIncludeSubDom   bool   `toml:"hsts_include_subdomains"`
+	HSTSPreload         bool   `toml:"hsts_preload"`
 }
 
 // Logging config

--- a/pkg/api/api.go
+++ b/pkg/api/api.go
@@ -3,6 +3,7 @@ package api
 import (
 	"context"
 	"crypto/tls"
+	"fmt"
 	"net/http"
 	"time"
 
@@ -26,6 +27,39 @@ func Init(config *acmedns.AcmeDnsConfig, db acmedns.AcmednsDB, logger *zap.Sugar
 	return a
 }
 
+func (a *AcmednsAPI) buildHSTSHeader() string {
+	if !a.Config.API.HSTSEnabled {
+		return ""
+	}
+
+	maxAge := a.Config.API.HSTSMaxAge
+	if maxAge <= 0 {
+		maxAge = 31536000
+	}
+
+	header := fmt.Sprintf("max-age=%d", maxAge)
+
+	if a.Config.API.HSTSIncludeSubDom {
+		header += "; includeSubDomains"
+	}
+
+	if a.Config.API.HSTSPreload {
+		header += "; preload"
+	}
+
+	return header
+}
+
+func (a *AcmednsAPI) hstsMiddleware(next httprouter.Handle) httprouter.Handle {
+	return func(w http.ResponseWriter, r *http.Request, ps httprouter.Params) {
+		hstsHeader := a.buildHSTSHeader()
+		if hstsHeader != "" {
+			w.Header().Set("Strict-Transport-Security", hstsHeader)
+		}
+		next(w, r, ps)
+	}
+}
+
 func (a *AcmednsAPI) Start(dnsservers []acmedns.AcmednsNS) {
 	var err error
 	//TODO: do we want to debug log the HTTP server?
@@ -46,10 +80,10 @@ func (a *AcmednsAPI) Start(dnsservers []acmedns.AcmednsNS) {
 		c.Log = stderrorlog
 	}
 	if !a.Config.API.DisableRegistration {
-		api.POST("/register", a.webRegisterPost)
+		api.POST("/register", a.hstsMiddleware(a.webRegisterPost))
 	}
-	api.POST("/update", a.Auth(a.webUpdatePost))
-	api.GET("/health", a.healthCheck)
+	api.POST("/update", a.hstsMiddleware(a.Auth(a.webUpdatePost)))
+	api.GET("/health", a.hstsMiddleware(a.healthCheck))
 
 	host := a.Config.API.IP + ":" + a.Config.API.Port
 


### PR DESCRIPTION
There was no way to add HSTS headers, making the service stand out on security audits and potentially be vulnerable to downgrade attacks. although only either HTTP and HTTPS can be served at a time, I thought it'd be worth implementing.

see https://github.com/OWASP/CheatSheetSeries/blob/master/cheatsheets/HTTP_Strict_Transport_Security_Cheat_Sheet.md

