### PR TITLE
task8: add metrics

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,7 +4,7 @@ LABEL maintainer="joona@kuori.org"
 RUN apk add --update git
 
 ENV GOPATH /tmp/buildcache
-RUN git clone https://github.com/joohoi/acme-dns /tmp/acme-dns
+COPY . /tmp/acme-dns
 WORKDIR /tmp/acme-dns
 RUN CGO_ENABLED=0 go build
 

--- a/go.mod
+++ b/go.mod
@@ -16,6 +16,7 @@ require (
 	github.com/lib/pq v1.10.7
 	github.com/mholt/acmez/v3 v3.1.2
 	github.com/miekg/dns v1.1.65
+	github.com/prometheus/client_golang v1.22.0
 	github.com/rs/cors v1.8.3
 	go.uber.org/zap v1.27.0
 	golang.org/x/crypto v0.38.0

--- a/pkg/api/api.go
+++ b/pkg/api/api.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/caddyserver/certmagic"
 	"github.com/julienschmidt/httprouter"
+	"github.com/prometheus/client_golang/prometheus/promhttp"
 	"github.com/rs/cors"
 	"go.uber.org/zap"
 )
@@ -50,6 +51,7 @@ func (a *AcmednsAPI) Start(dnsservers []acmedns.AcmednsNS) {
 	}
 	api.POST("/update", a.Auth(a.webUpdatePost))
 	api.GET("/health", a.healthCheck)
+	api.Handler(http.MethodGet, "/metrics", promhttp.Handler())
 
 	host := a.Config.API.IP + ":" + a.Config.API.Port
 

--- a/pkg/api/healthcheck.go
+++ b/pkg/api/healthcheck.go
@@ -1,12 +1,36 @@
 package api
 
 import (
+	"encoding/json"
 	"net/http"
 
 	"github.com/julienschmidt/httprouter"
 )
 
+type healthResponse struct {
+	Status   string `json:"status"`
+	Database string `json:"database"`
+	Message  string `json:"message,omitempty"`
+}
+
 // Endpoint used to check the readiness and/or liveness (health) of the server.
 func (a *AcmednsAPI) healthCheck(w http.ResponseWriter, r *http.Request, _ httprouter.Params) {
+	w.Header().Set("Content-Type", "application/json")
+
+	if err := a.DB.GetBackend().Ping(); err != nil {
+		a.Logger.Warnw("Health check: database ping failed", "error", err.Error())
+		w.WriteHeader(http.StatusServiceUnavailable)
+		_ = json.NewEncoder(w).Encode(healthResponse{
+			Status:   "degraded",
+			Database: "error",
+			Message:  err.Error(),
+		})
+		return
+	}
+
 	w.WriteHeader(http.StatusOK)
+	_ = json.NewEncoder(w).Encode(healthResponse{
+		Status:   "ok",
+		Database: "ok",
+	})
 }

--- a/pkg/api/metrics.go
+++ b/pkg/api/metrics.go
@@ -1,0 +1,36 @@
+package api
+
+import (
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/client_golang/prometheus/promauto"
+)
+
+var (
+	challengeUpdatesTotal = promauto.NewCounterVec(
+		prometheus.CounterOpts{
+			Name: "acmedns_challenge_updates_total",
+			Help: "Total ACME challenge TXT record update attempts.",
+		},
+		[]string{"result"},
+	)
+
+	registrationsTotal = promauto.NewCounterVec(
+		prometheus.CounterOpts{
+			Name: "acmedns_registrations_total",
+			Help: "Total ACME DNS account registration attempts.",
+		},
+		[]string{"result"},
+	)
+
+	registeredAccounts = promauto.NewGauge(
+		prometheus.GaugeOpts{
+			Name: "acmedns_registered_accounts",
+			Help: "Current number of registered ACME DNS accounts.",
+		},
+	)
+)
+
+const (
+	metricLabelSuccess = "success"
+	metricLabelFailure = "failure"
+)

--- a/pkg/api/register.go
+++ b/pkg/api/register.go
@@ -29,6 +29,7 @@ func (a *AcmednsAPI) webRegisterPost(w http.ResponseWriter, r *http.Request, _ h
 	if len(bdata) > 0 {
 		err = json.Unmarshal(bdata, &aTXT)
 		if err != nil {
+			registrationsTotal.WithLabelValues(metricLabelFailure).Inc()
 			regStatus = http.StatusBadRequest
 			reg = jsonError("malformed_json_payload")
 			w.Header().Set("Content-Type", "application/json")
@@ -41,6 +42,7 @@ func (a *AcmednsAPI) webRegisterPost(w http.ResponseWriter, r *http.Request, _ h
 	// Fail with malformed CIDR mask in allowfrom
 	err = aTXT.AllowFrom.IsValid()
 	if err != nil {
+		registrationsTotal.WithLabelValues(metricLabelFailure).Inc()
 		regStatus = http.StatusBadRequest
 		reg = jsonError("invalid_allowfrom_cidr")
 		w.Header().Set("Content-Type", "application/json")
@@ -55,11 +57,14 @@ func (a *AcmednsAPI) webRegisterPost(w http.ResponseWriter, r *http.Request, _ h
 		errstr := fmt.Sprintf("%v", err)
 		reg = jsonError(errstr)
 		regStatus = http.StatusInternalServerError
+		registrationsTotal.WithLabelValues(metricLabelFailure).Inc()
 		a.Logger.Errorw("Error in registration",
 			"error", err.Error())
 	} else {
 		a.Logger.Debugw("Created new user",
 			"user", nu.Username.String())
+		registrationsTotal.WithLabelValues(metricLabelSuccess).Inc()
+		registeredAccounts.Inc()
 		regStruct := RegResponse{nu.Username.String(), nu.Password, nu.Subdomain + "." + a.Config.General.Domain, nu.Subdomain, nu.AllowFrom.ValidEntries()}
 		regStatus = http.StatusCreated
 		reg, err = json.Marshal(regStruct)

--- a/pkg/api/update.go
+++ b/pkg/api/update.go
@@ -25,6 +25,7 @@ func (a *AcmednsAPI) webUpdatePost(w http.ResponseWriter, r *http.Request, _ htt
 			"error", "subdomain",
 			"subdomain", atxt.Subdomain,
 			"txt", atxt.Value)
+		challengeUpdatesTotal.WithLabelValues(metricLabelFailure).Inc()
 		updStatus = http.StatusBadRequest
 		upd = jsonError("bad_subdomain")
 	} else if !validTXT(atxt.Value) {
@@ -32,6 +33,7 @@ func (a *AcmednsAPI) webUpdatePost(w http.ResponseWriter, r *http.Request, _ htt
 			"error", "txt",
 			"subdomain", atxt.Subdomain,
 			"txt", atxt.Value)
+		challengeUpdatesTotal.WithLabelValues(metricLabelFailure).Inc()
 		updStatus = http.StatusBadRequest
 		upd = jsonError("bad_txt")
 	} else if validSubdomain(atxt.Subdomain) && validTXT(atxt.Value) {
@@ -39,12 +41,14 @@ func (a *AcmednsAPI) webUpdatePost(w http.ResponseWriter, r *http.Request, _ htt
 		if err != nil {
 			a.Logger.Errorw("Error while trying to update record",
 				"error", err.Error())
+			challengeUpdatesTotal.WithLabelValues(metricLabelFailure).Inc()
 			updStatus = http.StatusInternalServerError
 			upd = jsonError("db_error")
 		} else {
 			a.Logger.Debugw("TXT record updated",
 				"subdomain", atxt.Subdomain,
 				"txt", atxt.Value)
+			challengeUpdatesTotal.WithLabelValues(metricLabelSuccess).Inc()
 			updStatus = http.StatusOK
 			upd = []byte("{\"txt\": \"" + atxt.Value + "\"}")
 		}


### PR DESCRIPTION
Add /metrics endpoint with challenge update, registration counters and
registered accounts gauge. Extend /health to verify DB connectivity and
return structured JSON for K8s liveness/readiness probes.
