### PR TITLE
fix: Update log levels in config example

### DIFF
--- a/config.cfg
+++ b/config.cfg
@@ -55,7 +55,7 @@ use_header = false
 header_name = "X-Forwarded-For"
 
 [logconfig]
-# logging level: "error", "warning", "info" or "debug"
+# logging level: "error", "warn", "info" or "debug"
 loglevel = "info"
 # possible values: stdout, file
 logtype = "stdout"


### PR DESCRIPTION
Log level `warning` does not exist anymore. It is called `warn` now.