### PR TITLE
Fix initialization of nameservers

### DIFF
--- a/main.go
+++ b/main.go
@@ -38,14 +38,14 @@ func main() {
 		"file", usedConfigFile)
 	sugar.Info("Starting up")
 	db, err := database.Init(&config, sugar)
+	if err != nil {
+		sugar.Fatal(err)
+	}
 	// Error channel for servers
 	errChan := make(chan error, 1)
 	api := api.Init(&config, db, sugar, errChan)
 	dnsservers := nameserver.InitAndStart(&config, db, sugar, errChan)
 	go api.Start(dnsservers)
-	if err != nil {
-		sugar.Error(err)
-	}
 	for {
 		err = <-errChan
 		if err != nil {

--- a/pkg/acmedns/interfaces.go
+++ b/pkg/acmedns/interfaces.go
@@ -19,6 +19,5 @@ type AcmednsDB interface {
 type AcmednsNS interface {
 	Start(errorChannel chan error)
 	SetOwnAuthKey(key string)
-	SetNotifyStartedFunc(func())
 	ParseRecords()
 }

--- a/pkg/nameserver/initialize.go
+++ b/pkg/nameserver/initialize.go
@@ -32,7 +32,6 @@ type Nameserver struct {
 
 func InitAndStart(config *acmedns.AcmeDnsConfig, db acmedns.AcmednsDB, logger *zap.SugaredLogger, errChan chan error) []acmedns.AcmednsNS {
 	dnsservers := make([]acmedns.AcmednsNS, 0)
-	waitLock := sync.Mutex{}
 	if strings.HasPrefix(config.General.Proto, "both") {
 
 		// Handle the case where DNS server should be started for both udp and tcp
@@ -52,21 +51,13 @@ func InitAndStart(config *acmedns.AcmeDnsConfig, db acmedns.AcmednsDB, logger *z
 		dnsservers = append(dnsservers, dnsServerTCP)
 		dnsServerTCP.ParseRecords()
 		// wait for the server to get started to proceed
-		waitLock.Lock()
-		dnsServerUDP.SetNotifyStartedFunc(waitLock.Unlock)
 		go dnsServerUDP.Start(errChan)
-		waitLock.Lock()
-		dnsServerTCP.SetNotifyStartedFunc(waitLock.Unlock)
 		go dnsServerTCP.Start(errChan)
-		waitLock.Lock()
 	} else {
 		dnsServer := NewDNSServer(config, db, logger, config.General.Proto)
 		dnsservers = append(dnsservers, dnsServer)
 		dnsServer.ParseRecords()
-		waitLock.Lock()
-		dnsServer.SetNotifyStartedFunc(waitLock.Unlock)
 		go dnsServer.Start(errChan)
-		waitLock.Lock()
 	}
 	return dnsservers
 }
@@ -92,15 +83,8 @@ func (n *Nameserver) Start(errorChannel chan error) {
 	n.Logger.Infow("Starting DNS listener",
 		"addr", n.Server.Addr,
 		"proto", n.Server.Net)
-	if n.NotifyStartedFunc != nil {
-		n.Server.NotifyStartedFunc = n.NotifyStartedFunc
-	}
 	err := n.Server.ListenAndServe()
 	if err != nil {
 		errorChannel <- fmt.Errorf("DNS server %s failed: %w", n.Server.Net, err)
 	}
-}
-
-func (n *Nameserver) SetNotifyStartedFunc(fun func()) {
-	n.Server.NotifyStartedFunc = fun
 }


### PR DESCRIPTION
The current initialization code contains a deadlock resulting in #423.

Let's not attempt to wait for the nameservers to report back they managed to initialize, and instead let them fail for any reason — be it failure to initialize or runtime error, — and then just shut the process down if any such error is reported.
