### PR TITLE
Index txt.Subdomain and bound the DNS read path (#425 follow-up)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## Unreleased
+- Add index on `txt(Subdomain)` so DNS lookups no longer degrade to full table scans as registrations grow (created idempotently on startup, applies to existing databases)
+- Split DB timeouts: a short read timeout on the DNS hot path so a stalled connection no longer pins a worker for 20s after the resolver has already given up
+- Recycle idle PostgreSQL connections within a minute (`SetConnMaxIdleTime`) so a silently-dropped TCP connection is retired before it stalls the next query borrowing it
+
 ## v2.0
 - Update goreleaser configuration and add a GitHub action to build a release on new version tags (#395)
 - Huge refactoring and modernization (#325)

--- a/pkg/database/db.go
+++ b/pkg/database/db.go
@@ -36,6 +36,13 @@ var DBVersion = 1
 // DNS hot path and leaking a goroutine per query until the process is OOM-killed.
 const dbDefaultTimeout = 20 * time.Second
 
+// dbReadTimeout bounds the DNS hot-path read (GetTXTForDomain). It is deliberately
+// much shorter than dbDefaultTimeout: a DNS resolver abandons the query within a
+// few seconds, so a 20s ceiling only lets a stalled connection pin a worker long
+// after the client has given up. Failing fast frees the connection and prevents
+// the goroutine pileup that bounded-but-still-slow reads would otherwise cause.
+const dbReadTimeout = 5 * time.Second
+
 var acmeTable = `
 	CREATE TABLE IF NOT EXISTS acmedns(
 		Name TEXT,
@@ -64,6 +71,15 @@ var txtTablePG = `
 		Value   TEXT NOT NULL DEFAULT '',
 		LastUpdate INT
 	);`
+
+// txtIndex backs the DNS hot-path lookup (SELECT ... FROM txt WHERE Subdomain=$1).
+// Without it every DNS query is a full table scan whose latency grows with the
+// number of registered accounts, eventually crossing the read timeout under load.
+// CREATE INDEX IF NOT EXISTS is idempotent and valid for both SQLite and
+// PostgreSQL, so existing deployments gain the index on the next startup with no
+// explicit migration step.
+var txtIndex = `
+	CREATE INDEX IF NOT EXISTS idx_txt_subdomain ON txt (Subdomain);`
 
 // getSQLiteStmt replaces all PostgreSQL prepared statement placeholders (eg. $1, $2) with SQLite variant "?"
 func getSQLiteStmt(s string) string {
@@ -97,6 +113,10 @@ func Init(config *acmedns.AcmeDnsConfig, logger *zap.SugaredLogger) (acmedns.Acm
 		d.DB.SetMaxOpenConns(10)
 		d.DB.SetMaxIdleConns(2)
 		d.DB.SetConnMaxLifetime(5 * time.Minute)
+		// Recycle idle connections quickly so a silently-dropped TCP connection is
+		// retired within a minute instead of lingering until ConnMaxLifetime and
+		// stalling the next query that borrows it.
+		d.DB.SetConnMaxIdleTime(1 * time.Minute)
 	}
 	// Check version first to try to catch old versions without version string
 	var versionString string
@@ -111,6 +131,7 @@ func Init(config *acmedns.AcmeDnsConfig, logger *zap.SugaredLogger) (acmedns.Acm
 	} else {
 		_, _ = d.DB.Exec(txtTablePG)
 	}
+	_, _ = d.DB.Exec(txtIndex)
 	// If everything is fine, handle db upgrade tasks
 	if err == nil {
 		err = d.checkDBUpgrades(versionString)
@@ -295,7 +316,7 @@ func (d *acmednsdb) GetByUsername(u uuid.UUID) (acmedns.ACMETxt, error) {
 func (d *acmednsdb) GetTXTForDomain(domain string) ([]string, error) {
 	d.Mutex.RLock()
 	defer d.Mutex.RUnlock()
-	ctx, cancel := context.WithTimeout(context.Background(), dbDefaultTimeout)
+	ctx, cancel := context.WithTimeout(context.Background(), dbReadTimeout)
 	defer cancel()
 	domain = acmedns.SanitizeString(domain)
 	var txts []string

--- a/pkg/database/db_test.go
+++ b/pkg/database/db_test.go
@@ -306,3 +306,19 @@ func TestUpdate(t *testing.T) {
 		t.Errorf("DB Update failed, got error: [%v]", err)
 	}
 }
+
+func TestTXTSubdomainIndex(t *testing.T) {
+	// The DNS hot path filters txt rows by Subdomain on every query; without this
+	// index the lookup degrades to a full table scan as registrations grow.
+	DB := fakeDB()
+	backend := DB.GetBackend()
+	var name string
+	err := backend.QueryRow(
+		"SELECT name FROM sqlite_master WHERE type='index' AND name='idx_txt_subdomain'").Scan(&name)
+	if err != nil {
+		t.Errorf("Expected idx_txt_subdomain index to exist after Init, got error [%v]", err)
+	}
+	if name != "idx_txt_subdomain" {
+		t.Errorf("Expected index name [idx_txt_subdomain], got [%s]", name)
+	}
+}


### PR DESCRIPTION
#425 bounded DB ops at 20s, which converted a process-killing deadlock into visible "context deadline exceeded" / "Error while trying to get record" errors on the DNS hot path. The timeout was never the cause -- it surfaced a slow read that previously hung forever:

- txt.Subdomain had no index, so every DNS query (SELECT Value FROM txt WHERE Subdomain=$1) was a full table scan whose latency grew with the number of registrations until it crossed the 20s ceiling under load. Add idx_txt_subdomain, created idempotently on startup via CREATE INDEX IF NOT EXISTS so existing databases pick it up with no migration step. EXPLAIN QUERY PLAN now reports "SEARCH txt USING INDEX idx_txt_subdomain" instead of a full scan.

- Split the timeout: GetTXTForDomain (the DNS hot path) now uses a 5s read timeout instead of 20s. A resolver abandons the query within seconds, so a 20s ceiling only lets a stalled connection pin a worker long after the client gave up. Writes keep the 20s default.

- Recycle idle PostgreSQL connections within a minute (SetConnMaxIdleTime) so a silently-dropped TCP connection is retired before it stalls the next query that borrows it, rather than lingering until ConnMaxLifetime.

Verified: go build, go vet, go test -race ./pkg/... all pass; new TestTXTSubdomainIndex asserts the index exists after Init.