### PR TITLE
Add DNS protocol to logger

### DIFF
--- a/pkg/nameserver/initialize.go
+++ b/pkg/nameserver/initialize.go
@@ -73,7 +73,7 @@ func InitAndStart(config *acmedns.AcmeDnsConfig, db acmedns.AcmednsDB, logger *z
 
 // NewDNSServer parses the DNS records from config and returns a new DNSServer struct
 func NewDNSServer(config *acmedns.AcmeDnsConfig, db acmedns.AcmednsDB, logger *zap.SugaredLogger, proto string) acmedns.AcmednsNS {
-	//		dnsServerTCP := NewDNSServer(DB, Config.General.Listen, tcpProto, Config.General.Domain)
+	logger = logger.With("protocol", proto)
 	server := Nameserver{Config: config, DB: db, Logger: logger}
 	server.Server = &dns.Server{Addr: config.General.Listen, Net: proto}
 	domain := config.General.Domain


### PR DESCRIPTION
Adds a field to the Nameserver server logger to include the protocol attached to a given log line.